### PR TITLE
[libc++][ranges] LWG4035: `single_view` should provide `empty`

### DIFF
--- a/libcxx/include/__ranges/single_view.h
+++ b/libcxx/include/__ranges/single_view.h
@@ -70,6 +70,8 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI constexpr const _Tp* end() const noexcept { return data() + 1; }
 
+  _LIBCPP_HIDE_FROM_ABI static constexpr bool empty() noexcept { return false; }
+
   _LIBCPP_HIDE_FROM_ABI static constexpr size_t size() noexcept { return 1; }
 
   _LIBCPP_HIDE_FROM_ABI constexpr _Tp* data() noexcept { return __value_.operator->(); }

--- a/libcxx/test/std/ranges/range.factories/range.single.view/empty.pass.cpp
+++ b/libcxx/test/std/ranges/range.factories/range.single.view/empty.pass.cpp
@@ -27,7 +27,8 @@ constexpr void test_empty(T value) {
   using SingleView = std::ranges::single_view<T>;
   SingleView sv{value};
 
-  assert(!SingleView::empty());
+  std::same_as<bool> decltype(auto) result = SingleView::empty();
+  assert(result == false);
   static_assert(noexcept(SingleView::empty()));
   static_assert(noexcept(std::ranges::empty(sv)));
   static_assert(noexcept(std::ranges::empty(std::as_const(sv))));

--- a/libcxx/test/std/ranges/range.factories/range.single.view/empty.pass.cpp
+++ b/libcxx/test/std/ranges/range.factories/range.single.view/empty.pass.cpp
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// static constexpr bool empty() noexcept;
+
+#include <cassert>
+#include <concepts>
+#include <ranges>
+#include <utility>
+
+#include "test_macros.h"
+
+struct Empty {};
+struct BigType {
+  char buffer[64] = {10};
+};
+
+template <typename T>
+constexpr void test_empty(T value) {
+  using SingleView = std::ranges::single_view<T>;
+  SingleView sv{value};
+
+  assert(!SingleView::empty());
+  static_assert(noexcept(SingleView::empty()));
+  static_assert(noexcept(std::ranges::empty(sv)));
+  static_assert(noexcept(std::ranges::empty(std::as_const(sv))));
+}
+
+constexpr bool test() {
+  test_empty<int>(92);
+  test_empty<Empty>(Empty{});
+  test_empty<BigType>(BigType{});
+
+  return true;
+}
+
+int main(int, char**) {
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcxx/test/std/ranges/range.factories/range.single.view/empty.pass.cpp
+++ b/libcxx/test/std/ranges/range.factories/range.single.view/empty.pass.cpp
@@ -25,13 +25,27 @@ struct BigType {
 template <typename T>
 constexpr void test_empty(T value) {
   using SingleView = std::ranges::single_view<T>;
-  SingleView sv{value};
 
-  std::same_as<bool> decltype(auto) result = SingleView::empty();
-  assert(result == false);
-  static_assert(noexcept(SingleView::empty()));
-  static_assert(noexcept(std::ranges::empty(sv)));
-  static_assert(noexcept(std::ranges::empty(std::as_const(sv))));
+  {
+    std::same_as<bool> decltype(auto) result = SingleView::empty();
+    assert(result == false);
+    static_assert(noexcept(SingleView::empty()));
+  }
+
+  {
+    SingleView sv{value};
+
+    std::same_as<bool> decltype(auto) result = std::ranges::empty(sv);
+    assert(result == false);
+    static_assert(noexcept(std::ranges::empty(sv)));
+  }
+  {
+    const SingleView sv{value};
+
+    std::same_as<bool> decltype(auto) result = std::ranges::empty(sv);
+    assert(result == false);
+    static_assert(noexcept(std::ranges::empty(std::as_const(sv))));
+  }
 }
 
 constexpr bool test() {


### PR DESCRIPTION
Implements: https://wg21.link/LWG4035